### PR TITLE
Refactored Span and Token types

### DIFF
--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -38,9 +38,9 @@ pub enum TokenKind {
     GreaterThanOrEqual, // >=
 
     // idents
-    Identifier(String), // variable/type names
+    Identifier, // variable/type names
 
-    IntLiteral(isize),
+    IntLiteral,
 
     Eof,
 }
@@ -75,8 +75,8 @@ impl Display for TokenKind {
             TokenKind::GreaterThan => ">",
             TokenKind::LessThanOrEqual => "<=",
             TokenKind::GreaterThanOrEqual => ">=",
-            TokenKind::Identifier(i) => i,
-            TokenKind::IntLiteral(i) => &format!("{i}"),
+            TokenKind::Identifier => "identifier",
+            TokenKind::IntLiteral => "integer literal",
             TokenKind::Eof => "EOF",
         };
         f.write_str(str)
@@ -90,10 +90,10 @@ pub struct Token {
 }
 
 impl Token {
-    pub fn new(kind: TokenKind, source: &str, start: usize, size: usize) -> Self {
+    pub fn new(kind: TokenKind, start: usize, size: usize) -> Self {
         Token {
             kind,
-            span: Span::from_text(source, start, start + size - 1),
+            span: Span::from_range(start, start + size),
         }
     }
 }


### PR DESCRIPTION
So, I did a bunch of stuff, but the main part of it is just changing the `Span` type to hold indices for the start and end, and changing the `TokenKind` type to just hold the token type and no extra data.

In the lexer, I refactored the code to use the `CharIndices` struct and only use one level of peeking now. It's more efficient, and works better for this case.

In the parser, I changed all the tests to just use the byte indexes instead of the line and column numbers, and it looks like they all pass. Also, because there's no data in the `TokenKind`s, I instantiate the AST by slicing the source string with the token span.